### PR TITLE
https gate links enable

### DIFF
--- a/ext/main.dart
+++ b/ext/main.dart
@@ -334,7 +334,12 @@ class WebRequestRedirect {
     if (_errorMode) {
       urls.addAll(makeIpfsGlobs(settings.server));
     } else {
+      urls.addAll(makeIpfsGlobs('https://gateway.ipfs.io'));
       urls.addAll(makeIpfsGlobs('http://gateway.ipfs.io'));
+	  urls.addAll(makeIpfsGlobs('https://ipfs.io'));
+      urls.addAll(makeIpfsGlobs('http://ipfs.io'));
+      urls.addAll(makeIpfsGlobs('https://ipfs.pics'));
+      urls.addAll(makeIpfsGlobs('http://ipfs.pics'));
     }
     _ipfsRequestUrls = urls.map((url) => Uri.parse(url)).toList(growable: false);
   }


### PR DESCRIPTION
mai inglish is bed

links  https://gateway.ipfs.io don`t works and not redirecting

Несколько дней назад ipfs.io перешёл на https. В плагине работали ссылки начинающиеся на секьюрный протокол, покопавшись нашёл где заставляет работать

Вообще хорошо бы предусмотреть, чтобы все ссылки http[s]?://*/ipfs/QmSk2TKF9yigGY5m5Ut2hpUD2maAUAzJpPc2p4tc7e7XNw 
в не зависимости от доменаредиректились, т.к. наблюдает тенденция к увеличению количества гейтов. Или мб в настройках стоит сделать список обрабатываемых гейтов
